### PR TITLE
added Sort on PersistentList, a lock around file save, Mini-Biggy has…

### DIFF
--- a/Mini-Biggy.Tests/MemDataStore.cs
+++ b/Mini-Biggy.Tests/MemDataStore.cs
@@ -1,22 +1,27 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace MiniBiggy.Tests {
-    public class MemDataStore : IDataStore {
-
+namespace MiniBiggy.Tests
+{
+    public class MemDataStore : IDataStore
+    {
         public byte[] Json { get; set; }
         public bool ThrowOnSave { get; set; }
 
-        public MemDataStore() {
+        public MemDataStore()
+        {
             Json = new byte[0];
         }
 
-        public async Task<byte[]> ReadAllAsync() {
+        public async Task<byte[]> ReadAllAsync()
+        {
             return await Task.FromResult(Json);
         }
 
-        public async Task WriteAllAsync(byte[] json) {
-            if (ThrowOnSave) {
+        public async Task WriteAllAsync(byte[] json)
+        {
+            if (ThrowOnSave)
+            {
                 throw new Exception("SaveError");
             }
             Json = json;

--- a/Mini-Biggy.Tests/Mini-Biggy.Tests.csproj
+++ b/Mini-Biggy.Tests/Mini-Biggy.Tests.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>MiniBiggy.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -17,5 +21,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/Mini-Biggy.Tests/PersistentListIntegration.cs
+++ b/Mini-Biggy.Tests/PersistentListIntegration.cs
@@ -1,61 +1,64 @@
-﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using System.Reflection;
-using System.Diagnostics;
-using MiniBiggy.DataStores;
-using System.Text;
+﻿using MiniBiggy.DataStores;
 using MiniBiggy.SaveStrategies;
 using MiniBiggy.Serializers;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
-namespace MiniBiggy.Tests {
-    public class PersistentListIntegration : IDisposable {
-
+namespace MiniBiggy.Tests
+{
+    public class PersistentListIntegration : IDisposable
+    {
         private PersistentList<Tweet> _list;
         private FileSystem _store;
         private string _file;
 
-        public PersistentListIntegration() {
+        public PersistentListIntegration()
+        {
             _file = Path.Combine(Path.GetTempPath(), "foo.jss");
             File.Delete(_file);
             Directory.CreateDirectory(Path.GetDirectoryName(_file));
             _list = new PersistentList<Tweet>(
-                _store = new FileSystem(_file), 
+                _store = new FileSystem(_file),
                 new PrettyJsonSerializer(),
                 new SaveOnlyWhenRequested());
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             File.Delete(_file);
             Directory.CreateDirectory(Path.GetDirectoryName(_file));
         }
 
         [Fact]
-        public async Task Shoud_save_on_desired_path() {
+        public async Task Shoud_save_on_desired_path()
+        {
             var fs = new FileSystem(_file);
             await fs.WriteAllAsync(Encoding.UTF8.GetBytes("json"));
             Assert.True(File.Exists(_file));
         }
 
-
         [Fact]
-        public void Should_throw_when_saving_is_not_possible() {
+        public void Should_throw_when_saving_is_not_possible()
+        {
             var tweet = new Tweet { Username = "Foo" };
             _list.Add(tweet);
             _list.Save();
             FileStream fs = null;
-            try {
+            try
+            {
                 fs = File.Open(_file, FileMode.Open, FileAccess.Read, FileShare.None);
                 _list.Add(tweet);
                 _list.Save();
                 Assert.True(false, "Should throw exception!");
             }
-            catch (Exception) {}
-            finally {
+            catch (Exception) { }
+            finally
+            {
                 fs?.Dispose();
             }
         }
-        
     }
 }

--- a/Mini-Biggy.Tests/PersistentListTests.cs
+++ b/Mini-Biggy.Tests/PersistentListTests.cs
@@ -1,31 +1,35 @@
 ﻿using System;
-using MiniBiggy.SaveStrategies;
-using System.Threading.Tasks;
-using System.Text;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
-namespace MiniBiggy.Tests {
-    public class PersistentListTests {
+namespace MiniBiggy.Tests
+{
+    public class PersistentListTests
+    {
         private PersistentList<Tweet> _list;
         private MemDataStore _store;
 
-        
-        public PersistentListTests() {
+        public PersistentListTests()
+        {
             _list = new PersistentList<Tweet>(_store = new MemDataStore(), null, null);
         }
 
         [Fact]
-        public async Task Should_save_async() {
+        public async Task Should_save_async()
+        {
             _list.Add(new Tweet());
             await _list.SaveAsync();
             Assert.Equal("[{\"$id\":\"1\",\"Username\":null,\"Message\":null,\"DateTime\":\"0001-01-01T00:00:00\"}]", Encoding.UTF8.GetString(_store.Json));
         }
 
         [Fact]
-        public async Task Should_fire_event_when_saving_async() {
+        public async Task Should_fire_event_when_saving_async()
+        {
             var eventCalled = false;
-            _list.Saved += (sender, args) => {
+            _list.Saved += (sender, args) =>
+            {
                 eventCalled = true;
             };
             _list.Add(new Tweet());
@@ -34,10 +38,12 @@ namespace MiniBiggy.Tests {
         }
 
         [Fact]
-        public async Task Should_fire_event_with_exception_when_saving_error() {
+        public async Task Should_fire_event_with_exception_when_saving_error()
+        {
             _store.ThrowOnSave = true;
             Exception ex = null;
-            _list.Saved += (sender, args) => {
+            _list.Saved += (sender, args) =>
+            {
                 ex = args.Exception;
                 Assert.False(args.Success);
             };
@@ -47,14 +53,16 @@ namespace MiniBiggy.Tests {
         }
 
         [Fact]
-        public void Should_save_sync() {
+        public void Should_save_sync()
+        {
             _list.Add(new Tweet());
             _list.Save();
             Assert.Equal("[{\"$id\":\"1\",\"Username\":null,\"Message\":null,\"DateTime\":\"0001-01-01T00:00:00\"}]", Encoding.UTF8.GetString(_store.Json));
         }
 
         [Fact]
-        public void Objects_references_are_preserved() {
+        public void Objects_references_are_preserved()
+        {
             var tweet = new Tweet { Username = "Foo" };
             _list.Add(tweet);
             _list.Add(tweet);

--- a/Mini-Biggy.Tests/SaveStrategies/BackgroundSaveTests.cs
+++ b/Mini-Biggy.Tests/SaveStrategies/BackgroundSaveTests.cs
@@ -1,25 +1,30 @@
-﻿using System;
-using System.Threading;
-using MiniBiggy.SaveStrategies;
+﻿using MiniBiggy.SaveStrategies;
 using MiniBiggy.Util;
+using System;
+using System.Threading;
 using Xunit;
 
-namespace MiniBiggy.Tests.SaveStrategies {
-    public class BackgroundSaveTests {
-
+namespace MiniBiggy.Tests.SaveStrategies
+{
+    public class BackgroundSaveTests
+    {
         [Fact]
-        public void Calling_save_marks_as_dirty() {
+        public void Calling_save_marks_as_dirty()
+        {
             var strategy = new BackgroundSave(TimeSpan.FromSeconds(10));
             strategy.ShouldSaveNow();
             Assert.True(strategy.IsDirty);
         }
 
         [Fact]
-        public void Should_notify_save_when_dirty() {
+        public void Should_notify_save_when_dirty()
+        {
             var saveCalled = false;
-            using (var sem = new Semaphore(0, 1)) {
+            using (var sem = new Semaphore(0, 1))
+            {
                 var strategy = new BackgroundSave(TimeSpan.FromMilliseconds(100));
-                strategy.NotifyUnsolicitedSave += (sender, args) => {
+                strategy.NotifyUnsolicitedSave += (sender, args) =>
+                {
                     saveCalled = true;
                     sem.Release();
                 };
@@ -31,11 +36,14 @@ namespace MiniBiggy.Tests.SaveStrategies {
         }
 
         [Fact]
-        public void Should_not_notify_save_when_not_dirty() {
-            using (var sem = new Semaphore(0, 1)) {
+        public void Should_not_notify_save_when_not_dirty()
+        {
+            using (var sem = new Semaphore(0, 1))
+            {
                 var saveCalled = false;
                 var strategy = new BackgroundSave(TimeSpan.FromSeconds(10));
-                strategy.NotifyUnsolicitedSave += (sender, args) => {
+                strategy.NotifyUnsolicitedSave += (sender, args) =>
+                {
                     saveCalled = true;
                     sem.Release();
                 };

--- a/Mini-Biggy.Tests/Tweet.cs
+++ b/Mini-Biggy.Tests/Tweet.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 
-namespace MiniBiggy.Tests {
-    public class Tweet {
+namespace MiniBiggy.Tests
+{
+    public class Tweet
+    {
         public string Username { get; set; }
         public string Message { get; set; }
         public DateTime DateTime { get; set; }

--- a/Mini-Biggy.Tests/Util/TimeMachineTests.cs
+++ b/Mini-Biggy.Tests/Util/TimeMachineTests.cs
@@ -1,20 +1,24 @@
-﻿using System;
+﻿using MiniBiggy.Util;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using MiniBiggy.Util;
 using Xunit;
 
-namespace MiniBiggy.Tests.Util {
-    public class TimeMachineTests {
+namespace MiniBiggy.Tests.Util
+{
+    public class TimeMachineTests
+    {
         [Fact]
-        public void Shoul_replace_now() {
+        public void Shoul_replace_now()
+        {
             var fixedDate = new DateTime(2015, 1, 1);
             TimeMachine.OverrideNowWith(() => fixedDate);
             Assert.Equal(fixedDate, TimeMachine.Now);
         }
 
         [Fact]
-        public async Task Should_override_delay() {
+        public async Task Should_override_delay()
+        {
             TimeMachine.OverrideDelayWith(orig => TimeSpan.Zero);
             var sw = new Stopwatch();
             sw.Start();
@@ -23,9 +27,12 @@ namespace MiniBiggy.Tests.Util {
         }
 
         [Fact]
-        public async Task Should_unblock_delay() {
-            var task = Task.Run(async () => {
-                while (TimeMachine.UnblockAllDelays() == 0) {
+        public async Task Should_unblock_delay()
+        {
+            var task = Task.Run(async () =>
+            {
+                while (TimeMachine.UnblockAllDelays() == 0)
+                {
                     await Task.Delay(10);
                 }
             });

--- a/Mini-Biggy/BackupStrategies/BackupAttemptedEventArgs.cs
+++ b/Mini-Biggy/BackupStrategies/BackupAttemptedEventArgs.cs
@@ -1,17 +1,21 @@
 ﻿using System;
 
-namespace MiniBiggy.BackupStrategies {
-    public class BackupAttemptedEventArgs : EventArgs {
+namespace MiniBiggy.BackupStrategies
+{
+    public class BackupAttemptedEventArgs : EventArgs
+    {
         public string BackupPath { get; }
         public bool Success { get; }
         public Exception Exception { get; }
 
-        public BackupAttemptedEventArgs(string backupPath) {
+        public BackupAttemptedEventArgs(string backupPath)
+        {
             BackupPath = backupPath;
             Success = true;
         }
 
-        public BackupAttemptedEventArgs(BackupException ex) {
+        public BackupAttemptedEventArgs(BackupException ex)
+        {
             BackupPath = ex.Path;
             Exception = ex.InnerException;
         }

--- a/Mini-Biggy/BackupStrategies/BackupEverySave.cs
+++ b/Mini-Biggy/BackupStrategies/BackupEverySave.cs
@@ -1,20 +1,27 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace MiniBiggy.BackupStrategies {
-    public class BackupEverySave<T> : IBackupStrategy where T : new() {
+namespace MiniBiggy.BackupStrategies
+{
+    public class BackupEverySave<T> : IBackupStrategy where T : new()
+    {
         public event EventHandler<BackupAttemptedEventArgs> BackupAttempted;
 
-        public BackupEverySave(PersistentList<T> list, string listPath, string pathToSaveTheBackup, int maxNumberOfFilesToKeep = 10) {
+        public BackupEverySave(PersistentList<T> list, string listPath, string pathToSaveTheBackup, int maxNumberOfFilesToKeep = 10)
+        {
             var backup = new FileSystemBackup(listPath, pathToSaveTheBackup, maxNumberOfFilesToKeep);
 
-            list.Saved += (sender, args) => {
-                Task.Run(() => {
-                    try {
+            list.Saved += (sender, args) =>
+            {
+                Task.Run(() =>
+                {
+                    try
+                    {
                         var backupPath = backup.Backup();
                         BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(backupPath));
                     }
-                    catch (BackupException ex) {
+                    catch (BackupException ex)
+                    {
                         BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(ex));
                     }
                 });

--- a/Mini-Biggy/BackupStrategies/DailyBackup.cs
+++ b/Mini-Biggy/BackupStrategies/DailyBackup.cs
@@ -1,37 +1,41 @@
 ﻿using System;
-using System.Threading.Tasks;
-using MiniBiggy.Util;
+using System.Threading;
 
-namespace MiniBiggy.BackupStrategies {
-    public class DailyBackup : IBackupStrategy {
+namespace MiniBiggy.BackupStrategies
+{
+    public class DailyBackup : IBackupStrategy
+    {
         private readonly int _hourBase;
         private FileSystemBackup _backup;
+        private Timer _timer;
 
         public event EventHandler<BackupAttemptedEventArgs> BackupAttempted;
 
-        public DailyBackup(int hourBase, string listPath, string pathToSaveTheBackup, int maxNumberOfFilesToKeep = 10) {
+        public DailyBackup(int hourBase, string listPath, string pathToSaveTheBackup, int maxNumberOfFilesToKeep = 10)
+        {
             _hourBase = hourBase;
             _backup = new FileSystemBackup(listPath, pathToSaveTheBackup, maxNumberOfFilesToKeep);
         }
 
-        public void Start() {
-            Task.Factory.StartNew(Loop, TaskCreationOptions.LongRunning);
+        public void Start()
+        {
+            var startAt = TimeSpan.FromHours(_hourBase) - DateTime.Now.TimeOfDay;
+            if (startAt.Ticks < 0)
+                startAt += TimeSpan.FromDays(1);
+
+            _timer = new Timer(state => Loop(), null, startAt, TimeSpan.FromDays(1));
         }
 
-        private async Task Loop() {
-            while (true) {
-                await TimeMachine.Delay(TimeSpan.FromMinutes(1));
-                var currentHour = TimeMachine.Now.Hour;
-                if (currentHour != _hourBase) {
-                    return;
-                }
-                try {
-                    var backupPath = _backup.Backup();
-                    BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(backupPath));
-                }
-                catch (BackupException ex) {
-                    BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(ex));
-                }
+        private void Loop()
+        {
+            try
+            {
+                var backupPath = _backup.Backup();
+                BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(backupPath));
+            }
+            catch (BackupException ex)
+            {
+                BackupAttempted?.Invoke(this, new BackupAttemptedEventArgs(ex));
             }
         }
     }

--- a/Mini-Biggy/BackupStrategies/FileSystemBackup.cs
+++ b/Mini-Biggy/BackupStrategies/FileSystemBackup.cs
@@ -1,47 +1,57 @@
-﻿using System;
+﻿using MiniBiggy.Util;
+using System;
 using System.IO;
 using System.Linq;
-using MiniBiggy.Util;
 
-namespace MiniBiggy.BackupStrategies {
-    public class FileSystemBackup {
+namespace MiniBiggy.BackupStrategies
+{
+    public class FileSystemBackup
+    {
         private readonly string _backupFrom, _filenameWithoutExtension, _backupToDir;
         private readonly int _maxNumberOfFilesToKeep;
 
-        public FileSystemBackup(string backupFrom, string backupToDir, int maxNumberOfFilesToKeep) {
+        public FileSystemBackup(string backupFrom, string backupToDir, int maxNumberOfFilesToKeep)
+        {
             _backupFrom = backupFrom;
             _filenameWithoutExtension = Path.GetFileNameWithoutExtension(backupFrom);
             _backupToDir = backupToDir;
             _maxNumberOfFilesToKeep = maxNumberOfFilesToKeep;
         }
 
-        public string Backup() {
+        public string Backup()
+        {
             Directory.CreateDirectory(_backupToDir);
             var backupPath = Path.Combine(_backupToDir, $"{_filenameWithoutExtension}_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.bkp");
-            try {
+            try
+            {
                 File.Copy(_backupFrom, backupPath, true);
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 throw new BackupException(backupPath, ex);
             }
             RemoveOldFiles();
             return backupPath;
         }
 
-        private void RemoveOldFiles() {
+        private void RemoveOldFiles()
+        {
             var dirInfo = new DirectoryInfo(_backupToDir);
             var files = dirInfo.GetFiles("*.bkp", SearchOption.AllDirectories)
                 .OrderByDescending(f => f.CreationTime);
-            foreach (var fileInfo in files.Skip(_maxNumberOfFilesToKeep)) {
+            foreach (var fileInfo in files.Skip(_maxNumberOfFilesToKeep))
+            {
                 Try.SwallowingExceptions(() => fileInfo.Delete());
             }
         }
     }
 
-    public class BackupException : Exception {
+    public class BackupException : Exception
+    {
         public string Path { get; set; }
 
-        public BackupException(string path, Exception inner) : base("Could not perform backup. See inner exception for more details", inner) {
+        public BackupException(string path, Exception inner) : base("Could not perform backup. See inner exception for more details", inner)
+        {
             Path = path;
         }
     }

--- a/Mini-Biggy/BackupStrategies/IBackupStrategy.cs
+++ b/Mini-Biggy/BackupStrategies/IBackupStrategy.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 
-namespace MiniBiggy.BackupStrategies {
-    public interface IBackupStrategy {
+namespace MiniBiggy.BackupStrategies
+{
+    public interface IBackupStrategy
+    {
         event EventHandler<BackupAttemptedEventArgs> BackupAttempted;
     }
 }

--- a/Mini-Biggy/ConfigureBackup.cs
+++ b/Mini-Biggy/ConfigureBackup.cs
@@ -1,48 +1,60 @@
 ﻿using MiniBiggy.BackupStrategies;
 
-namespace MiniBiggy {
-    public class ConfigureBackup : IChooseTargetDirectory, IChooseNumberOfFilesToKeep, IChooseBackupKind {
-
+namespace MiniBiggy
+{
+    public class ConfigureBackup : IChooseTargetDirectory, IChooseNumberOfFilesToKeep, IChooseBackupKind
+    {
         private string _sourceDir, _targetDir;
         private int _filesToKeep;
 
-        private ConfigureBackup() { }
+        private ConfigureBackup()
+        {
+        }
 
-        public static IChooseTargetDirectory CopyListFrom(string sourceDir) {
+        public static IChooseTargetDirectory CopyListFrom(string sourceDir)
+        {
             var config = new ConfigureBackup();
             config._sourceDir = sourceDir;
             return config;
         }
 
-        public IChooseNumberOfFilesToKeep ToDirectory(string dirPath) {
+        public IChooseNumberOfFilesToKeep ToDirectory(string dirPath)
+        {
             _targetDir = dirPath;
             return this;
         }
 
-        public IChooseBackupKind KeepNewest(int numberOfFiles) {
+        public IChooseBackupKind KeepNewest(int numberOfFiles)
+        {
             _filesToKeep = numberOfFiles;
             return this;
         }
 
-        public IBackupStrategy BackupEveryDayAtHour(int hourOfDay) {
+        public IBackupStrategy BackupEveryDayAtHour(int hourOfDay)
+        {
             return new DailyBackup(hourOfDay, _sourceDir, _targetDir, _filesToKeep);
         }
 
-        public IBackupStrategy BackupEverySave<T>(PersistentList<T> list) where T : new() {
+        public IBackupStrategy BackupEverySave<T>(PersistentList<T> list) where T : new()
+        {
             return new BackupEverySave<T>(list, _sourceDir, _targetDir, _filesToKeep);
         }
     }
 
-    public interface IChooseTargetDirectory {
+    public interface IChooseTargetDirectory
+    {
         IChooseNumberOfFilesToKeep ToDirectory(string dirPath);
     }
 
-    public interface IChooseNumberOfFilesToKeep {
+    public interface IChooseNumberOfFilesToKeep
+    {
         IChooseBackupKind KeepNewest(int numberOfFiles);
     }
 
-    public interface IChooseBackupKind {
+    public interface IChooseBackupKind
+    {
         IBackupStrategy BackupEveryDayAtHour(int hourOfDay);
+
         IBackupStrategy BackupEverySave<T>(PersistentList<T> list) where T : new();
     }
 }

--- a/Mini-Biggy/Create.cs
+++ b/Mini-Biggy/Create.cs
@@ -1,6 +1,9 @@
-﻿namespace MiniBiggy {
-    public static class Create {
-        public static CreateListOf<T> ListOf<T>() where T : new() {
+﻿namespace MiniBiggy
+{
+    public static class Create
+    {
+        public static CreateListOf<T> ListOf<T>() where T : new()
+        {
             return new CreateListOf<T>();
         }
     }

--- a/Mini-Biggy/CreateList.cs
+++ b/Mini-Biggy/CreateList.cs
@@ -3,86 +3,105 @@ using MiniBiggy.SaveStrategies;
 using MiniBiggy.Serializers;
 using System;
 
-namespace MiniBiggy {
-
+namespace MiniBiggy
+{
     [Obsolete("Use Create.ListOf<T> instead")]
-    public class CreateList<T> : IChooseSerializer<T>, IChooseSaveMode<T> where T : new() {
+    public class CreateList<T> : IChooseSerializer<T>, IChooseSaveMode<T> where T : new()
+    {
         private IDataStore _dataStore;
         private ISerializer _serializer;
         private ISaveStrategy _saveStrategy;
 
-        private CreateList() { }
+        private CreateList()
+        {
+        }
 
-        public static IChooseSerializer<T> SavingAt(string fullpath) {
+        public static IChooseSerializer<T> SavingAt(string fullpath)
+        {
             var builder = new CreateList<T>();
             builder._dataStore = new FileSystem(fullpath);
             return builder;
         }
 
-        public IChooseSaveMode<T> UsingJsonSerializer() {
+        public IChooseSaveMode<T> UsingJsonSerializer()
+        {
             _serializer = new JsonSerializer();
             return this;
         }
 
-        public IChooseSaveMode<T> UsingPrettyJsonSerializer() {
+        public IChooseSaveMode<T> UsingPrettyJsonSerializer()
+        {
             _serializer = new PrettyJsonSerializer();
             return this;
         }
 
-        public PersistentList<T> BackgroundSavingEvery(TimeSpan timeSpan) {
+        public PersistentList<T> BackgroundSavingEvery(TimeSpan timeSpan)
+        {
             _saveStrategy = new BackgroundSave(timeSpan);
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEverySecond() {
+        public PersistentList<T> BackgroundSavingEverySecond()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(1));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryTwoSeconds() {
+        public PersistentList<T> BackgroundSavingEveryTwoSeconds()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(2));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryFiveSeconds() {
+        public PersistentList<T> BackgroundSavingEveryFiveSeconds()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(5));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryMinute() {
+        public PersistentList<T> BackgroundSavingEveryMinute()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromMinutes(1));
             return Create();
         }
 
-        public PersistentList<T> SavingWhenCollectionChanges() {
+        public PersistentList<T> SavingWhenCollectionChanges()
+        {
             _saveStrategy = new SaveOnEveryChange();
             return Create();
         }
 
-        public PersistentList<T> SavingWhenRequested() {
+        public PersistentList<T> SavingWhenRequested()
+        {
             _saveStrategy = new SaveOnlyWhenRequested();
             return Create();
         }
 
-        private PersistentList<T> Create() {
-            if (_serializer == null) {
+        private PersistentList<T> Create()
+        {
+            if (_serializer == null)
+            {
                 _serializer = new JsonSerializer();
             }
-            if (_saveStrategy == null) {
+            if (_saveStrategy == null)
+            {
                 _saveStrategy = new SaveOnlyWhenRequested();
             }
             return new PersistentList<T>(_dataStore, _serializer, _saveStrategy);
         }
     }
 
-    public interface IChooseSerializer<T> where T : new() {
+    public interface IChooseSerializer<T> where T : new()
+    {
         IChooseSaveMode<T> UsingJsonSerializer();
-        IChooseSaveMode<T> UsingPrettyJsonSerializer();
 
+        IChooseSaveMode<T> UsingPrettyJsonSerializer();
     }
 
-    public interface IChooseSaveMode<T> where T : new() {
+    public interface IChooseSaveMode<T> where T : new()
+    {
         PersistentList<T> BackgroundSavingEvery(TimeSpan timeSpan);
+
         PersistentList<T> BackgroundSavingEverySecond();
 
         PersistentList<T> BackgroundSavingEveryTwoSeconds();

--- a/Mini-Biggy/CreateListOf.cs
+++ b/Mini-Biggy/CreateListOf.cs
@@ -3,73 +3,89 @@ using MiniBiggy.SaveStrategies;
 using MiniBiggy.Serializers;
 using System;
 
-namespace MiniBiggy {
-
-    public class CreateListOf<T> where T : new() {
-        public IChooseSerializer<T> SavingAt(string fullpath) {
+namespace MiniBiggy
+{
+    public class CreateListOf<T> where T : new()
+    {
+        public IChooseSerializer<T> SavingAt(string fullpath)
+        {
             return new CreateListOfBuilder<T>(new FileSystem(fullpath));
         }
     }
 
-    public class CreateListOfBuilder<T> : IChooseSerializer<T>, IChooseSaveMode<T> where T : new() {
+    public class CreateListOfBuilder<T> : IChooseSerializer<T>, IChooseSaveMode<T> where T : new()
+    {
         private IDataStore _dataStore;
         private ISerializer _serializer;
         private ISaveStrategy _saveStrategy;
 
-        public CreateListOfBuilder(IDataStore dataStore) {
+        public CreateListOfBuilder(IDataStore dataStore)
+        {
             _dataStore = dataStore;
         }
-        
-        public IChooseSaveMode<T> UsingJsonSerializer() {
+
+        public IChooseSaveMode<T> UsingJsonSerializer()
+        {
             _serializer = new JsonSerializer();
             return this;
         }
 
-        public IChooseSaveMode<T> UsingPrettyJsonSerializer() {
+        public IChooseSaveMode<T> UsingPrettyJsonSerializer()
+        {
             _serializer = new PrettyJsonSerializer();
             return this;
         }
 
-        public PersistentList<T> BackgroundSavingEvery(TimeSpan timeSpan) {
+        public PersistentList<T> BackgroundSavingEvery(TimeSpan timeSpan)
+        {
             _saveStrategy = new BackgroundSave(timeSpan);
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEverySecond() {
+        public PersistentList<T> BackgroundSavingEverySecond()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(1));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryTwoSeconds() {
+        public PersistentList<T> BackgroundSavingEveryTwoSeconds()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(2));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryFiveSeconds() {
+        public PersistentList<T> BackgroundSavingEveryFiveSeconds()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromSeconds(5));
             return Create();
         }
 
-        public PersistentList<T> BackgroundSavingEveryMinute() {
+        public PersistentList<T> BackgroundSavingEveryMinute()
+        {
             _saveStrategy = new BackgroundSave(TimeSpan.FromMinutes(1));
             return Create();
         }
 
-        public PersistentList<T> SavingWhenCollectionChanges() {
+        public PersistentList<T> SavingWhenCollectionChanges()
+        {
             _saveStrategy = new SaveOnEveryChange();
             return Create();
         }
 
-        public PersistentList<T> SavingWhenRequested() {
+        public PersistentList<T> SavingWhenRequested()
+        {
             _saveStrategy = new SaveOnlyWhenRequested();
             return Create();
         }
 
-        private PersistentList<T> Create() {
-            if (_serializer == null) {
+        private PersistentList<T> Create()
+        {
+            if (_serializer == null)
+            {
                 _serializer = new JsonSerializer();
             }
-            if (_saveStrategy == null) {
+            if (_saveStrategy == null)
+            {
                 _saveStrategy = new SaveOnlyWhenRequested();
             }
             return new PersistentList<T>(_dataStore, _serializer, _saveStrategy);

--- a/Mini-Biggy/DataStores/FileSystem.cs
+++ b/Mini-Biggy/DataStores/FileSystem.cs
@@ -1,39 +1,57 @@
-﻿using System;
-using MiniBiggy.Util;
+﻿using MiniBiggy.Util;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace MiniBiggy.DataStores {
-    public class FileSystem : IDataStore {
+namespace MiniBiggy.DataStores
+{
+    public class FileSystem : IDataStore
+    {
+        private static readonly object SyncRoot = new object();
+
         public string FullPath { get; }
-        public FileSystem(string fullPath) {
+
+        public FileSystem(string fullPath)
+        {
             FullPath = fullPath;
         }
-        
-        public virtual async Task<byte[]> ReadAllAsync() {
-            if (!File.Exists(FullPath)) {
+
+        public virtual async Task<byte[]> ReadAllAsync()
+        {
+            if (!File.Exists(FullPath))
+            {
                 return new byte[0];
             }
             return await Try.ThreeTimesAsync(() => File.ReadAllBytes(FullPath));
         }
 
-        public virtual async Task WriteAllAsync(byte[] bytes) {
+        public virtual async Task WriteAllAsync(byte[] bytes)
+        {
             await WriteAllAsync(bytes, FullPath);
         }
 
-        public virtual async Task WriteAllAsync(byte[] bytes, string path) {
+        public virtual async Task WriteAllAsync(byte[] bytes, string path)
+        {
             var directory = Path.GetDirectoryName(path);
-            if (directory != "") {
+            if (directory != "")
+            {
                 Directory.CreateDirectory(directory);
             }
-            await Try.ThreeTimesAsync(async () => {
-                File.Delete(path + ".old");
-                if (File.Exists(path)) {
-                    File.Move(path, path + ".old");
+            await Try.ThreeTimesAsync(async () =>
+            {
+                lock (SyncRoot)
+                {
+                    if (File.Exists(path))
+                    {
+                        var old = $"{path}.old";
+                        File.Delete(old);
+                        File.Move(path, old);
+                    }
+                    using (var fs = new FileStream(FullPath, FileMode.OpenOrCreate, FileAccess.Write))
+                    {
+                        fs.WriteAsync(bytes, 0, bytes.Length);
+                    }
                 }
-                using (var fs = new FileStream(FullPath, FileMode.OpenOrCreate, FileAccess.Write)) {
-                    await fs.WriteAsync(bytes, 0, bytes.Length);
-                }
+                await Task.Delay(0);
             }, 300);
         }
     }

--- a/Mini-Biggy/DataStores/IDataStore.cs
+++ b/Mini-Biggy/DataStores/IDataStore.cs
@@ -1,8 +1,11 @@
 ﻿using System.Threading.Tasks;
 
-namespace MiniBiggy {
-    public interface IDataStore {
+namespace MiniBiggy
+{
+    public interface IDataStore
+    {
         Task<byte[]> ReadAllAsync();
+
         Task WriteAllAsync(byte[] list);
     }
 }

--- a/Mini-Biggy/Mini-Biggy.csproj
+++ b/Mini-Biggy/Mini-Biggy.csproj
@@ -1,28 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0</VersionPrefix>
-    <Authors>Andre Carlucci</Authors>
-    <TargetFramework>netstandard1.6</TargetFramework>
-    <AssemblyName>Mini-Biggy</AssemblyName>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <RootNamespace>MiniBiggy</RootNamespace>
     <PackageId>mini-biggy</PackageId>
-    <PackageTags>biggy documentstore json linq nosql sql database filesystem vnext netstandard</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/mini-biggy/mini-biggy/master/Assets/mini_biggy.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/mini-biggy/mini-biggy</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/mini-biggy/mini-biggy/blob/master/LICENSE</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>2.1</Version>
+    <Authors>Andre Carlucci</Authors>
+    <Company>Andre Carlucci</Company>
+    <Product>Mini-Biggy</Product>
     <Description>Mini-Biggy is a Very Fast Document/Relational Query Tool with Full LINQ Compliance.</Description>
+    <PackageLicenseUrl>https://github.com/mini-biggy/mini-biggy/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/mini-biggy/mini-biggy</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/mini-biggy/mini-biggy/master/Assets/mini_biggy.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/mini-biggy/mini-biggy</RepositoryUrl>
+    <PackageTags>biggy documentstore json linq nosql sql database filesystem vnext netstandard</PackageTags>
+    <AssemblyName>Mini-Biggy</AssemblyName>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
 </Project>

--- a/Mini-Biggy/PersistedEventArgs.cs
+++ b/Mini-Biggy/PersistedEventArgs.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MiniBiggy {
-    public class PersistedEventArgs<T> : EventArgs {
+namespace MiniBiggy
+{
+    public class PersistedEventArgs<T> : EventArgs
+    {
         public List<T> Items { get; set; }
-        public PersistedEventArgs() {
+
+        public PersistedEventArgs()
+        {
             Items = new List<T>();
         }
 
-        public PersistedEventArgs(List<T> items) {
+        public PersistedEventArgs(List<T> items)
+        {
             Items = items;
         }
     }

--- a/Mini-Biggy/Properties/AssemblyInfo.cs
+++ b/Mini-Biggy/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Mini-Biggy/SaveStrategies/BackgroundSave.cs
+++ b/Mini-Biggy/SaveStrategies/BackgroundSave.cs
@@ -1,41 +1,52 @@
-﻿using System;
+﻿using MiniBiggy.Util;
+using System;
 using System.Threading.Tasks;
-using MiniBiggy.Util;
 
-namespace MiniBiggy.SaveStrategies {
-    public class BackgroundSave : ISaveStrategy {
+namespace MiniBiggy.SaveStrategies
+{
+    public class BackgroundSave : ISaveStrategy
+    {
         public event EventHandler NotifyUnsolicitedSave;
+
         public static TimeSpan DefaultIntervalBetweenSaves = TimeSpan.FromSeconds(2);
         public bool IsDirty { get; set; }
         public TimeSpan IntervalBetweenSaves { get; set; }
 
-        public BackgroundSave(TimeSpan interval) {
+        public BackgroundSave(TimeSpan interval)
+        {
             IntervalBetweenSaves = interval;
             Task.Run(async () => await Loop());
         }
 
-        private async Task Loop() {
-            while (true) {
+        private async Task Loop()
+        {
+            while (true)
+            {
                 await TimeMachine.Delay(IntervalBetweenSaves);
-                if (!IsDirty) {
+                if (!IsDirty)
+                {
                     continue;
                 }
-                try {
+                try
+                {
                     OnNotifySave();
                     IsDirty = false;
                 }
-                catch {
+                catch
+                {
                     await TimeMachine.Delay(IntervalBetweenSaves);
                 }
             }
         }
 
-        public bool ShouldSaveNow() {
+        public bool ShouldSaveNow()
+        {
             IsDirty = true;
             return false;
         }
 
-        protected virtual void OnNotifySave() {
+        protected virtual void OnNotifySave()
+        {
             NotifyUnsolicitedSave?.Invoke(this, EventArgs.Empty);
         }
     }

--- a/Mini-Biggy/SaveStrategies/ISaveStrategy.cs
+++ b/Mini-Biggy/SaveStrategies/ISaveStrategy.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 
-namespace MiniBiggy.SaveStrategies {
-    public interface ISaveStrategy {
+namespace MiniBiggy.SaveStrategies
+{
+    public interface ISaveStrategy
+    {
         event EventHandler NotifyUnsolicitedSave;
+
         bool ShouldSaveNow();
     }
 }

--- a/Mini-Biggy/SaveStrategies/SaveOnEveryChange.cs
+++ b/Mini-Biggy/SaveStrategies/SaveOnEveryChange.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 
-namespace MiniBiggy.SaveStrategies {
-    public class SaveOnEveryChange : ISaveStrategy {
+namespace MiniBiggy.SaveStrategies
+{
+    public class SaveOnEveryChange : ISaveStrategy
+    {
         public event EventHandler NotifyUnsolicitedSave;
-        public bool ShouldSaveNow() {
+
+        public bool ShouldSaveNow()
+        {
             return true;
         }
     }

--- a/Mini-Biggy/SaveStrategies/SaveOnlyWhenRequested.cs
+++ b/Mini-Biggy/SaveStrategies/SaveOnlyWhenRequested.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 
-namespace MiniBiggy.SaveStrategies {
-    public class SaveOnlyWhenRequested : ISaveStrategy {
+namespace MiniBiggy.SaveStrategies
+{
+    public class SaveOnlyWhenRequested : ISaveStrategy
+    {
         public event EventHandler NotifyUnsolicitedSave;
-        public bool ShouldSaveNow() {
+
+        public bool ShouldSaveNow()
+        {
             return false;
         }
     }

--- a/Mini-Biggy/SavedEventArgs.cs
+++ b/Mini-Biggy/SavedEventArgs.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 
-namespace MiniBiggy {
-    public class SavedEventArgs : EventArgs {
+namespace MiniBiggy
+{
+    public class SavedEventArgs : EventArgs
+    {
         public Exception Exception { get; set; }
         public bool Success => Exception == null;
         public TimeSpan TimeToSerialize { get; set; }
         public TimeSpan TimeToSave { get; set; }
         public int SizeInBytes { get; set; }
-        public SavedEventArgs(Exception exception = null) {
+
+        public SavedEventArgs(Exception exception = null)
+        {
             Exception = exception;
         }
     }

--- a/Mini-Biggy/Serializers/ISerializer.cs
+++ b/Mini-Biggy/Serializers/ISerializer.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace MiniBiggy.Serializers {
-    public interface ISerializer {
+namespace MiniBiggy.Serializers
+{
+    public interface ISerializer
+    {
         byte[] Serialize<T>(List<T> list) where T : new();
+
         List<T> Deserialize<T>(byte[] list);
     }
 }

--- a/Mini-Biggy/Serializers/JsonSerializer.cs
+++ b/Mini-Biggy/Serializers/JsonSerializer.cs
@@ -1,22 +1,32 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
 
-namespace MiniBiggy.Serializers {
-    public class JsonSerializer : ISerializer {
-        public List<T> Deserialize<T>(byte[] bytes) {
-            var list = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-            return JsonConvert.DeserializeObject<List<T>>(list, new JsonSerializerSettings {
-                PreserveReferencesHandling = PreserveReferencesHandling.Objects
-            });
+namespace MiniBiggy.Serializers
+{
+    public class JsonSerializer : ISerializer
+    {
+        internal JsonSerializerSettings Settings
+        {
+            get
+            {
+                return new JsonSerializerSettings
+                {
+                    PreserveReferencesHandling = PreserveReferencesHandling.Objects
+                };
+            }
         }
 
-        public virtual byte[] Serialize<T>(List<T> list) where T : new() {
-            var json = JsonConvert.SerializeObject(list, new JsonSerializerSettings {
-                PreserveReferencesHandling = PreserveReferencesHandling.Objects
-            });
+        public List<T> Deserialize<T>(byte[] bytes)
+        {
+            var list = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+            return JsonConvert.DeserializeObject<List<T>>(list, Settings);
+        }
+
+        public virtual byte[] Serialize<T>(List<T> list) where T : new()
+        {
+            var json = JsonConvert.SerializeObject(list, Settings);
             return Encoding.UTF8.GetBytes(json);
         }
     }
-
 }

--- a/Mini-Biggy/Serializers/PrettyJsonSerializer.cs
+++ b/Mini-Biggy/Serializers/PrettyJsonSerializer.cs
@@ -1,17 +1,15 @@
-using System;
-using System.Linq;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
 
-namespace MiniBiggy.Serializers {
-    public class PrettyJsonSerializer : JsonSerializer {
-
-        public override byte[] Serialize<T>(List<T> list) {
-            var json = JsonConvert.SerializeObject(list, 
-                Formatting.Indented, new JsonSerializerSettings {
-                    PreserveReferencesHandling = PreserveReferencesHandling.Objects
-                });
+namespace MiniBiggy.Serializers
+{
+    public class PrettyJsonSerializer : JsonSerializer
+    {
+        public override byte[] Serialize<T>(List<T> list)
+        {
+            var json = JsonConvert.SerializeObject(list,
+                Formatting.Indented, Settings);
             return Encoding.UTF8.GetBytes(json);
         }
     }

--- a/Mini-Biggy/Util/TimeMachine.cs
+++ b/Mini-Biggy/Util/TimeMachine.cs
@@ -3,54 +3,71 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace MiniBiggy.Util {
-    public static class TimeMachine {
-        private static List<CancellationTokenSource> _tokens = new List<CancellationTokenSource>(); 
+namespace MiniBiggy.Util
+{
+    public static class TimeMachine
+    {
+        private static List<CancellationTokenSource> _tokens = new List<CancellationTokenSource>();
         private static object _syncRoot = new object();
         private static Func<DateTime> _nowFuncion = () => DateTime.Now;
         private static Func<TimeSpan, TimeSpan> _funcThatReturnsNewDelay = millisecondsDelay => millisecondsDelay;
         public static DateTime Now => _nowFuncion.Invoke();
-        public static void OverrideNowWith(Func<DateTime> func) {
+
+        public static void OverrideNowWith(Func<DateTime> func)
+        {
             _nowFuncion = func;
         }
-        public async static Task Delay(int millisecondsDelay) {
+
+        public async static Task Delay(int millisecondsDelay)
+        {
             await Delay(TimeSpan.FromMilliseconds(millisecondsDelay));
         }
 
-        public async static Task Delay(TimeSpan delay) {
+        public async static Task Delay(TimeSpan delay)
+        {
             var tokenSource = new CancellationTokenSource();
             var token = tokenSource.Token;
-            lock (_syncRoot) {
+            lock (_syncRoot)
+            {
                 _tokens.Add(tokenSource);
             }
-            try {
+            try
+            {
                 await Task.Delay(_funcThatReturnsNewDelay.Invoke(delay), token);
             }
-            catch(TaskCanceledException) {
+            catch (TaskCanceledException)
+            {
             }
-            lock (_syncRoot) {
+            lock (_syncRoot)
+            {
                 _tokens.Remove(tokenSource);
                 tokenSource.Dispose();
             }
         }
 
-        public static int UnblockOneOrMoreDelays() {
-            while (_tokens.Count == 0) {
+        public static int UnblockOneOrMoreDelays()
+        {
+            while (_tokens.Count == 0)
+            {
                 Task.Delay(10).Wait();
             }
             return UnblockAllDelays();
         }
 
-        public static int UnblockAllDelays() {
-            lock (_syncRoot) {
-                for (int i = 0; i < _tokens.Count; i++) {
+        public static int UnblockAllDelays()
+        {
+            lock (_syncRoot)
+            {
+                for (int i = 0; i < _tokens.Count; i++)
+                {
                     _tokens[i].Cancel(false);
                 }
                 return _tokens.Count;
             }
         }
 
-        public static void OverrideDelayWith(Func<TimeSpan, TimeSpan> funcThatReturnsNewDelay) {
+        public static void OverrideDelayWith(Func<TimeSpan, TimeSpan> funcThatReturnsNewDelay)
+        {
             _funcThatReturnsNewDelay = funcThatReturnsNewDelay;
         }
     }

--- a/Mini-Biggy/Util/Try.cs
+++ b/Mini-Biggy/Util/Try.cs
@@ -1,34 +1,45 @@
 using System;
 using System.Threading.Tasks;
 
-namespace MiniBiggy.Util {
-    public static class Try {
-        public static async Task ThreeTimesAsync(Func<Task> func, int increasingMillisecondsBetween = 100) {
-            await Again(async () => {
-                    await func.Invoke();
-                    return 1;
-                }
+namespace MiniBiggy.Util
+{
+    public static class Try
+    {
+        public static async Task ThreeTimesAsync(Func<Task> func, int increasingMillisecondsBetween = 100)
+        {
+            await Again(async () =>
+            {
+                await func.Invoke();
+                return 1;
+            }
             , 3, increasingMillisecondsBetween);
         }
 
-        public static async Task<T> ThreeTimesAsync<T>(Func<T> func, int increasingMillisecondsBetween = 100) {
-            return await Again(() => {
+        public static async Task<T> ThreeTimesAsync<T>(Func<T> func, int increasingMillisecondsBetween = 100)
+        {
+            return await Again(() =>
+            {
                 return Task.Run(() => func.Invoke());
             }
             , 3, increasingMillisecondsBetween);
         }
 
-        public static async Task<T> ThreeTimesAsync<T>(Func<Task<T>> func, int increasingMillisecondsBetween = 100) {
+        public static async Task<T> ThreeTimesAsync<T>(Func<Task<T>> func, int increasingMillisecondsBetween = 100)
+        {
             return await Again(func, 3, increasingMillisecondsBetween);
         }
 
-        public static async Task<T> Again<T>(Func<Task<T>> func, int times, int increasingMillisecondsBetween = 100) {
-            try {
+        public static async Task<T> Again<T>(Func<Task<T>> func, int times, int increasingMillisecondsBetween = 100)
+        {
+            try
+            {
                 return await func.Invoke();
             }
-            catch (Exception) {
+            catch (Exception)
+            {
                 times--;
-                if (times <= 0) {
+                if (times <= 0)
+                {
                     throw;
                 }
                 await Task.Delay(increasingMillisecondsBetween);
@@ -36,11 +47,14 @@ namespace MiniBiggy.Util {
             }
         }
 
-        public static void SwallowingExceptions(Action action) {
-            try {
+        public static void SwallowingExceptions(Action action)
+        {
+            try
+            {
                 action.Invoke();
             }
-            catch {
+            catch
+            {
                 // ignored
             }
         }

--- a/Sample.DotNetCoreCmd/Program.cs
+++ b/Sample.DotNetCoreCmd/Program.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using MiniBiggy;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using MiniBiggy;
-using MiniBiggy.DataStores;
-using MiniBiggy.SaveStrategies;
-using MiniBiggy.Serializers;
 
-namespace Sample.DotNetCoreCmd {
-    public class Program {
-        public static async Task Main(string[] args) {
+namespace Sample.DotNetCoreCmd
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
             var sw = new Stopwatch();
             sw.Start();
             var storagePath = @"db\tweets.json";
@@ -18,17 +17,20 @@ namespace Sample.DotNetCoreCmd {
                                              .BackgroundSavingEveryTwoSeconds();
 
             Console.WriteLine("Loaded: " + sw.Elapsed.TotalMilliseconds);
-            
 
-            list.Saved += (sender, arg) => {
-                Console.WriteLine($"-- Save: Serialize: {arg.TimeToSerialize} Save: {arg.TimeToSave} Size: {arg.SizeInBytes} Success: {arg.Success} Error: {arg.Exception?.ToString()??  "None"}" );
+            list.Saved += (sender, arg) =>
+            {
+                Console.WriteLine($"-- Save: Serialize: {arg.TimeToSerialize} Save: {arg.TimeToSave} Size: {arg.SizeInBytes} Success: {arg.Success} Error: {arg.Exception?.ToString() ?? "None"}");
             };
 
             var times = 1000000;
-            var result = Parallel.For(0, times, async (i) => {
-                list.Add(new Tweet {
+            var result = Parallel.For(0, times, async (i) =>
+            {
+                list.Add(new Tweet
+                {
                     Id = i,
-                    Message = "" + i }
+                    Message = "" + i
+                }
                 );
                 //await list.SaveAsync();
             });
@@ -68,7 +70,8 @@ namespace Sample.DotNetCoreCmd {
         }
     }
 
-    public class Tweet {
+    public class Tweet
+    {
         public int Id { get; set; }
         public string Message { get; set; }
         public DateTime DateTime { get; set; }

--- a/Sample.DotNetCoreCmd/Properties/AssemblyInfo.cs
+++ b/Sample.DotNetCoreCmd/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Sample.DotNetCoreCmd/Sample.DotNetCoreCmd.csproj
+++ b/Sample.DotNetCoreCmd/Sample.DotNetCoreCmd.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>Sample.DotNetCoreCmd</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Sample.DotNetCoreCmd</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -22,5 +21,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Mini-Biggy\Mini-Biggy.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
… now std 1.6 and 2.0 packages

many many CodeMaid changes are in the code, but this is not functional
on PersistentList we are now able to run all three known Sort overloads on the internal _items List
there was a threading problem on WriteAllAsync in FileSystem, so there is now a lock around
some minor refactorings on JsonSerializer, so the JsonSerializerSettings defined only once
on PersistentList UpdateItem adds the item if not in list like the original biggy
added the pr for 'Use Timer instead of infinite loop in DailyBackup'